### PR TITLE
Feature/artifact collections

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: check-yaml
+        args: ['--allow-multiple-documents']
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/gitleaks/gitleaks
@@ -25,3 +26,4 @@ repos:
     rev: v1.37.1
     hooks:
       - id: yamllint
+...

--- a/.yamllint
+++ b/.yamllint
@@ -13,7 +13,8 @@ rules:
   comments:
     min-spaces-from-content: 1
   comments-indentation: false
-  document-start: disable
+  document-start:
+    present: true
   line-length:
     max: 160
   braces:

--- a/ArtifactsCollections/README.md
+++ b/ArtifactsCollections/README.md
@@ -1,5 +1,5 @@
 # Location of the artifacts at operation systems
 
-Prepared filters which could be used as [Collection Filters](https://plaso.readthedocs.io/en/latest/sources/user/Collection-Filters.html#yaml-based-filter-file-format) during parsing with plaso.
+Prepared filters which could be used as [Collection Filters](https://plaso.readthedocs.io/en/latest/sources/user/Collection-Filters.html#yaml-based-filter-file-format) during parsing of disk image with plaso.
 
-Or it could be used also as source of locations of interesting files for DFIR.
+Or it could be used also as source of locations of interesting files for DFIR (for example for surge).

--- a/ArtifactsCollections/README.md
+++ b/ArtifactsCollections/README.md
@@ -1,4 +1,4 @@
-# Location of the artifacts at operation systems
+# Location of the artifacts at operating systems
 
 Prepared filters which could be used as [Collection Filters](https://plaso.readthedocs.io/en/latest/sources/user/Collection-Filters.html#yaml-based-filter-file-format) during parsing of disk image with plaso.
 

--- a/ArtifactsCollections/README.md
+++ b/ArtifactsCollections/README.md
@@ -1,0 +1,1 @@
+# Location of the artifacts at operation systems

--- a/ArtifactsCollections/README.md
+++ b/ArtifactsCollections/README.md
@@ -1,1 +1,5 @@
 # Location of the artifacts at operation systems
+
+Prepared filters which could be used as [Collection Filters](https://plaso.readthedocs.io/en/latest/sources/user/Collection-Filters.html#yaml-based-filter-file-format) during parsing with plaso.
+
+Or it could be used also as source of locations of interesting files for DFIR.

--- a/ArtifactsCollections/linux-collections.yaml
+++ b/ArtifactsCollections/linux-collections.yaml
@@ -1,0 +1,29 @@
+---
+description: System paths.
+type: include
+path_separator: '/'
+paths:
+- '/etc/cron.+'
+- '/etc/group'
+- '/etc/hostname'
+- '/etc/hosts[.]allow'
+- '/etc/hosts[.]deny'
+- '/etc/hosts'
+- '/etc/network/interfaces'
+- '/etc/network/interfaces.d/.+'
+- '/etc/os-release'
+- '/etc/passwd'
+- '/etc/sudoers'
+- '/etc/timezone'
+- '/var/log/.+'
+- '/var/spool/cron/crontabs/.+'
+---
+description: User's bash history.
+type: include
+path_separator: '/'
+paths:
+- '/home/.+/.bashrc'
+- '/home/.+/.bash_history'
+- '/root/.bashrc'
+- '/root/.bash_history'
+...

--- a/ArtifactsCollections/macos-collections.yaml
+++ b/ArtifactsCollections/macos-collections.yaml
@@ -1,0 +1,198 @@
+description: System paths.
+type: include
+path_separator: '/'
+paths:
+- '/[.]fseventsd/.+'
+- '/Applications/.+/Info[.]plist'
+- '/dev/auditpipe'
+- '/etc/group'
+- '/etc/hosts[.]allow'
+- '/etc/hosts[.]deny'
+- '/etc/hosts'
+- '/etc/passwd'
+- '/etc/rc[.]d/.+'
+- '/Library/Application Support/com[.]apple[.]TCC/TCC[.]db'
+- '/Library/CoreServices/.+'
+- '/Library/Keychains/System[.]keychain'
+- '/Library/LaunchAgents/.+'
+- '/Library/LaunchDaemons/.+'
+- '/Library/Preferences/.+'
+- '/Library/Receipts/InstallHistory[.]plist'
+- '/Library/StartupItems/.+'
+- '/private/etc/rc[.]d/.+'
+- '/private/etc/hosts[.]allow'
+- '/private/etc/hosts[.]deny'
+- '/private/etc/hosts'
+- '/private/etc/passwd'
+- '/private/etc/group'
+- '/private/var/audit/.+'
+- '/private/var/db/[.]AppleSetupDone'
+- '/private/var/db/com[.]apple[.]xpc[.]launchd/disabled[.]plist'
+- '/private/var/db/dhcpclient/leases/.+'
+- '/private/var/db/diagnostics/.+'
+- '/private/var/db/dslocal/nodes/Default/groups/.+'
+- '/private/var/db/dslocal/nodes/Default/sharepoints/.+[.]plist'
+- '/private/var/db/dslocal/nodes/Default/users/.+'
+- '/private/var/db/launchd[.]db/com[.]apple[.]launchd/overrides[.]plist'
+- '/private/var/db/powerlog/Library/BatteryLife/CurrentPowerlog[.]PLSQL'
+- '/private/var/db/powerlog/Library/BatteryLife/Archives/.+'
+- '/private/var/db/shadow/hash/.+[.]state'
+- '/private/var/db/softwareupdate/journal[.]plist'
+- '/private/var/db/uuidtext/.+'
+- '/private/var/folders/.+/0/com[.]apple[.]ScreenTimeAgent/RMAdminStore-Cloud[.]sqlite'
+- '/private/var/folders/.+/0/com[.]apple[.]ScreenTimeAgent/RMAdminStore-Local[.]sqlite'
+- '/private/var/log/.+'
+- '/private/var/root/Library/Caches/locations/cache_encryptedA[.]db'
+- '/System/Library/CoreServices/.+'
+- '/System/Library/LaunchAgents/.+'
+- '/System/Library/LaunchDaemons/.+'
+- '/System/Library/Preferences/.+'
+- '/System/Library/StartupItems/.+'
+- '/var/audit/.+'
+- '/var/db/com[.]apple[.]xpc[.]launchd/disabled[.]plist'
+- '/var/db/dhcpclient/leases/.+'
+- '/var/db/diagnostics/.+'
+- '/var/db/dslocal/nodes/Default/sharepoints/.+[.]plist'
+- '/var/db/launchd[.]db/com[.]apple[.]launchd/overrides[.]plist'
+- '/var/db/powerlog/Library/BatteryLife/CurrentPowerlog.PLSQL'
+- '/var/db/powerlog/Library/BatteryLife/Archives/.+'
+- '/var/db/receipts/.+'
+- '/var/db/uuidtext/.+'
+- '/var/folders/.+/0/com[.]apple[.]ScreenTimeAgent/RMAdminStore-Cloud[.]sqlite'
+- '/var/folders/.+/0/com[.]apple[.]ScreenTimeAgent/RMAdminStore-Local[.]sqlite'
+- '/var/log/.+'
+- '.+/Library/Accounts/.+[.]sqlite'
+- '.+/Library/Application Support/com[.]apple[.]backgroundtaskmanagementagent/backgrounditems[.]btm'
+- '.+/Library/Application Support/com[.]apple[.]sharedfilelist/.+[.]sfl'
+- '.+/Library/Application Support/com[.]apple[.]sharedfilelist/.+[.]sfl2'
+- '.+/Library/Application Support/com[.]apple[.]TCC/TCC[.]db'
+- '.+/Library/Application Support/Knowledge/knowledgeC[.]db'
+- '.+/Library/Caches/.+'
+- '.+/Library/Containers/.+/Preferences/.+[.]plist'
+- '.+/Library/Containers/.+/Cache/.+'
+- '.+/Library/Containers/com[.]apple[.]corerecents[.]recentsd/Data/Library/Recents/Recents'
+- '.+/Library/Keychains/.+'
+- '.+/Library/LaunchAgents/.+'
+- '.+/Library/Logs/fsck_hfs[.]log'
+- '.+/Library/Preferences/.+[.]plist'
+- '.+/Library/SyncedPreferences/com[.]apple[.]wifi[.]WiFiAgent[.]plist'
+- '.+/[.]ssh/known_hosts'
+- '.+/[.]ssh/authorized_hosts'
+---
+description: Third-Party Kernel Extensions.
+type: include
+path_separator: '/'
+paths:
+- '/private/var/db/loadedkextmt[.]plist'
+- '/Library/Apple/System/Library/Extensions/.+'
+- '/System/Library/Extensions/.+'
+- '/Library/Extensions/.+'
+- '/Library/StagedExtensions/.+'
+- '/Library/SystemExtensions/.+'
+- '/Library/.+/Extensions/.+'
+---
+description: Terminal history.
+type: include
+path_separator: '/'
+paths:
+- '/root/[.].+history'
+- '/Users/.+/[.].+history'
+---
+description: Apple Messages.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/Messages/chat[.]db'
+---
+description: Apple Contacts.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/Application Support/AddressBook/AddressBook-v22[.]abcddb'
+- '.+/Library/Application Support/AddressBook/Sources/.+/AddressBook-v22[.]abcddb'
+- '.+/Library/Application Support/AddressBook/Sources/.+/Metadata/.+'
+---
+description: Apple Call History.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/Application Support/CallHistoryDB/CallHistory[.]storedata'
+---
+description: Apple Mail.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/Mail/V\d{1,2}/.+/.+[.]mbox'
+- '.+/Library/Mail/V\d{1,2}/.+/[.]mboxCache[.]plist'
+- '.+/Library/Containers/com[.]apple[.]mail/.+'
+- '.+/Library/Mail/V\d{1,2}/MailData/Envelope Index.+'
+---
+description: Apple Calendar.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/Calendars/.+[.]calendar'
+- '.+/Library/Calendars/.+[.]caldav'
+- '.+/Library/Calendars/Calendar Cache.+'
+---
+description: Apple Notes.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/Group Containers/group[.]com[.]apple[.]notes/NoteStore[.]sqlite'
+- '.+/Library/Containers/com[.]apple[.]Notes/notes[.]sqlite'
+---
+description: Apple Reminders.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/Reminders/.+/Data-.+[.]sqlite'
+---
+description: Google Chrome paths.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/.+Support/Google/Chrome/Default/.+'
+- '.+/Library/.+Support/Google/Chrome/Default/History.+'
+- '.+/Library/.+Support/Google/Chrome/Default/Cookies.+'
+- '.+/Library/.+Support/Google/Chrome/Default/Bookmarks.+'
+- '.+/Library/.+Support/Google/Chrome/Default/Extensions/.+'
+- '.+/Library/.+Support/Google/Chrome/Default/Extensions/Last.+'
+- '.+/Library/.+Support/Google/Chrome/Default/Extensions/Shortcuts.+'
+- '.+/Library/.+Support/Google/Chrome/Default/Extensions/Top.+'
+- '.+/Library/.+Support/Google/Chrome/Default/Extensions/Visited.+'
+---
+description: Safari Browser paths.
+type: include
+path_separator: '/'
+paths:
+- '.+/Library/Safari/.+'
+- '.+/Library/Containers/com[.]apple[.]Safari/Data/Library/Caches/com[.]apple[.]Safari/.+'
+- '.+/Library/Cookies/Cookies[.]binarycookies'
+- '.+/Library/Safari/Downloads[.]plist'
+---
+description: OneDrive.
+type: include
+path_separator: '/'
+paths:
+- '/Users/.+/Library/Logs/OneDrive/.+'
+---
+description: Other Paths.
+type: include
+path_separator: '/'
+paths:
+- '.+/places[.]sqlite.+'
+- '.+/downloads[.]sqlite.+'
+---
+description: Bencoded files.
+type: include
+path_separator: '/'
+paths:
+- '/.+[.]torrent'
+---
+description: iCloud files.
+type: exclude
+path_separator: '/'
+paths:
+- '/Users/.+/iCloud Drive.+'
+- '/Users/.+/[.]Trash/iCloud Drive.+'

--- a/ArtifactsCollections/macos-collections.yaml
+++ b/ArtifactsCollections/macos-collections.yaml
@@ -1,3 +1,4 @@
+---
 description: System paths.
 type: include
 path_separator: '/'
@@ -196,3 +197,4 @@ path_separator: '/'
 paths:
 - '/Users/.+/iCloud Drive.+'
 - '/Users/.+/[.]Trash/iCloud Drive.+'
+...


### PR DESCRIPTION
This pull request introduces several changes to improve YAML file validation, enhance documentation, and add artifact collection configurations for Linux and macOS systems. The most significant updates include enabling stricter YAML validation rules, adding a README for artifact collection locations, and defining comprehensive artifact collection paths for forensic analysis.

### YAML Validation Improvements:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R14): Added the `--allow-multiple-documents` argument to the `check-yaml` hook to support files with multiple YAML documents.
* [`.yamllint`](diffhunk://#diff-27950a662421192db1847a8f44066c546c6f83964e90d1cd6a30bd02407a2f81L16-R17): Updated the `document-start` rule to require the presence of a document start marker (`---`) for stricter validation.

### Documentation Enhancements:
* [`ArtifactsCollections/README.md`](diffhunk://#diff-9517e7c25b268d7182059672c2935948a560161572bb88cec3c59b3168fe6506R1-R5): Added a new README file describing the purpose and use of artifact collection filters for digital forensics and incident response (DFIR).

### Artifact Collection Configurations:
* [`ArtifactsCollections/linux-collections.yaml`](diffhunk://#diff-c4e2da4ed8a897cd37b52e23914f0152d1fab0a1eb30767b4fad8fbbd2e45204R1-R29): Added paths for Linux system and user artifacts, including system configuration files, logs, and user bash history.
* [`ArtifactsCollections/macos-collections.yaml`](diffhunk://#diff-3cc3e5a05adb1cc6ee39130af68aec3ffb003192557841033cd1f9cd350ac59bR1-R200): Added paths for macOS system and user artifacts, covering system files, application data, browser history, and more. This includes specific paths for Apple applications like Safari, Mail, and Notes, as well as third-party tools like Google Chrome and OneDrive.