### PR TITLE
Add initial README.md for CTF write-ups and challenges

### DIFF
--- a/WriteUps/README.md
+++ b/WriteUps/README.md
@@ -1,0 +1,5 @@
+# Write-ups from different CTFs and other challenges
+
+This directory contains write-ups for various Capture The Flag (CTF) competitions and other challenges.
+The write-ups are organized by the name of the CTF or challenge, and each write-up includes a description of the challenge, the solution, and any relevant code or scripts used to solve it.
+The write-ups are intended to be a resource for anyone interested in learning more about CTFs and the techniques used to solve them.


### PR DESCRIPTION
This pull request adds a new `README.md` file to the `WriteUps` directory, providing an overview of its purpose and structure.

Documentation updates:

* [`WriteUps/README.md`](diffhunk://#diff-737053de2a7862d944d0958b3a5097b421d86ea40745c6ee687186703dbd2af2R1-R5): Introduced a `README.md` file that explains the directory contains write-ups for various Capture The Flag (CTF) competitions and challenges. It describes how the write-ups are organized and their intended purpose as a learning resource.